### PR TITLE
Androidにおける表示を修正した

### DIFF
--- a/yamiHikariGame/Classes/AppDelegate.cpp
+++ b/yamiHikariGame/Classes/AppDelegate.cpp
@@ -76,7 +76,7 @@ bool AppDelegate::applicationDidFinishLaunching()
     }
 #else
     // Android, etc...
-    if (screenSize.height < kIPadDesignResolutionHeight) {
+    if (screenSize.height < kIPadHeight) {
         openGLView->setDesignResolutionSize(kDefaultDesignResolutionWidth, kDefaultDesignResolutionHeight, kResolutionShowAll);
     }
     else {


### PR DESCRIPTION
Android端末において、以下のとおり表示されるようにした
- 端末サイズが1024より小さい場合
  -- iPhoneと同じ描画サイズでゲーム画面を生成し、アスペクト比を保持して画面全体が描画される
- 端末サイズが1024以上の場合
  -- iPadと同じ描画サイズでゲーム画面を生成し、アスペクト比を保持して画面全体が描画される
