### PR TITLE
Androidにおいて指定のフォントが使用されない問題を解決した

### DIFF
--- a/yamiHikariGame/Classes/Constants.h
+++ b/yamiHikariGame/Classes/Constants.h
@@ -10,7 +10,7 @@
 #define yamiHikariGame_Constants_h
 
 #define SpriteSheetImageFileName "spriteSheet.pvr.ccz"
-#define DefaultFontName "mosamosa"
+#define DefaultFontName "mosamosa.ttf"
 #define DefaultFontSize 24
 
 #define StaminaMax 1000


### PR DESCRIPTION
フォントの指定時に拡張子まで含めないと、Androidはフォントファイルを見つけられない。
