### PR TITLE
ドロップレートとスコア閾値の設定をみてアイテムを落とすようにした

### DIFF
--- a/yamiHikariGame/Classes/Constants.h
+++ b/yamiHikariGame/Classes/Constants.h
@@ -32,6 +32,7 @@
 #define SoundEffectVolume 0.15
 
 #define StaminaMax 1000
+#define SameTimeDropItemKindMax 3
 
 #define MessageItemBookTitle "アイテムずかん"
 #define MessageResultTitle "リザルト"

--- a/yamiHikariGame/Classes/DropItem.cpp
+++ b/yamiHikariGame/Classes/DropItem.cpp
@@ -9,10 +9,10 @@
 #include "DropItem.h"
 #include "GameEngine.h"
 
-DropItem *DropItem::create()
+DropItem *DropItem::create(Item item)
 {
     DropItem *dropItem = new DropItem();
-    if (dropItem && dropItem->init())
+    if (dropItem && dropItem->init(item))
     {
         dropItem->autorelease();
         return dropItem;
@@ -21,20 +21,10 @@ DropItem *DropItem::create()
     return NULL;
 }
 
-bool DropItem::init()
+bool DropItem::init(Item item)
 {
-    _item = selectItem();
+    _item = item;
     return CCSprite::initWithSpriteFrameName(_item->image.c_str());
-}
-
-Item DropItem::selectItem()
-{
-    vector<Item> *items = GameEngine::sharedEngine()->getItems();
-
-    int index = arc4random() % items->size();
-    Item item = items->at(index);
-
-    return item;
 }
 
 void DropItem::drop()

--- a/yamiHikariGame/Classes/DropItem.h
+++ b/yamiHikariGame/Classes/DropItem.h
@@ -19,10 +19,9 @@ class DropItem : public CCSprite
 protected:
     Item _item;
 
-    bool init();
-    Item selectItem();
+    bool init(Item item);
 public:
-    static DropItem *create();
+    static DropItem *create(Item item);
     void drop();
 
     int getItemID();

--- a/yamiHikariGame/Classes/GameScene.cpp
+++ b/yamiHikariGame/Classes/GameScene.cpp
@@ -131,12 +131,33 @@ void GameScene::dropItem()
     CCSize windowSize = CCDirector::sharedDirector()->getWinSize();
     float horizontalMargin = windowSize.width * kEmergedAreaHorizontalMarginRate;
     int emergedAreaWidth = windowSize.width - horizontalMargin * 2;
-    float positionX = arc4random() % emergedAreaWidth + horizontalMargin;
 
-    DropItem *item = DropItem::create();
-    item->setPosition(ccp(positionX, -item->getContentSize().height / 2));
-    _itemsNode->addChild(item);
-    item->drop();
+    GameEngine *engine = GameEngine::sharedEngine();
+
+    vector<Item> *items = engine->getItems();
+    vector<Item>::reverse_iterator iterator = items->rbegin();
+
+    int itemCount = 0;
+    while (iterator != items->rend()) {
+        Item item = *iterator;
+        float needle = (float)arc4random() / UINT32_MAX;
+
+        if (engine->getScore() > item->score_threshold && item->drop_rate > needle) {
+            float positionX = arc4random() % emergedAreaWidth + horizontalMargin;
+
+            DropItem *dropItem = DropItem::create(item);
+            dropItem->setPosition(ccp(positionX, -dropItem->getContentSize().height / 2));
+            _itemsNode->addChild(dropItem);
+            dropItem->drop();
+
+            itemCount++;
+            if (itemCount >= SameTimeDropItemKindMax) {
+                break;
+            }
+        }
+
+        iterator++;
+    }
 }
 
 void GameScene::collisionCheck()


### PR DESCRIPTION
設定ファイルに記述されているドロップ確率とスコアの閾値をみてアイテムを落とすようにしました。
アイテムは一度（同じライン）に最大3個まで配置されます。
アイテムIDの大きい方からアイテムドロップ判定が行われるのでよりレアっぽいものが落ちやすくなるはずです。
